### PR TITLE
Fix String.each for Ruby > 1.8

### DIFF
--- a/watch_tablet
+++ b/watch_tablet
@@ -18,7 +18,7 @@ end
 def activate_mode(mode)
   puts "Switching to #{mode} mode"
   if cmds = config['modes'][mode]
-    cmds.each{|cmd| system cmd }
+    cmds.each_char{|cmd| system cmd }
   end
 end
 


### PR DESCRIPTION
Recent Ruby versions seem to have removed String.each, but String.each_char should work.